### PR TITLE
Add initial tests for optional parameter routing.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.OData.Builder
         }
 
         /// <summary>
-        /// Specifies the bindingParameter name, type and whether it is alwaysBindable, use only if the operation "isBindable".
+        /// Specifies the bindingParameter name and type.
         /// </summary>
         internal void SetBindingParameterImplementation(string name, IEdmTypeConfiguration bindingParameterType)
         {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationController.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
                     City = "City" + i,
                 },
                 Emails = Enumerable.Range(1, i).Select(j => string.Format("Name{0}_{1}@microsoft.com", i, j)).ToList(),
-                Salary = i * 10,
+                Salary = i * 3 * 10000,
                 Heads = i,
             }).ToList();
 
@@ -44,7 +44,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
                     City = "City" + i,
                 },
                 Emails = Enumerable.Range(1, i).Select(j => string.Format("Name{0}_{1}@microsoft.com", i, j)).ToList(),
-                Salary = i * 10,
+                Salary = i * 2 * 10000,
             }).ToList();
 
             int k = 20;
@@ -59,7 +59,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
                     City = "City" + k,
                 },
                 Emails = new List<string>(),
-                Salary = k * 10,
+                Salary = k * 2 * 10000,
             });
 
 
@@ -272,6 +272,24 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
 
             return Ok();
         }
+
+        //// ~/Employees/Namespace.GetCount(minSalary=60000)
+        //// ~/Employees/Namespace.GetCount(minSalary=60000, maxSalary=80000)
+        //[HttpGet]
+        //[ODataRoute("Employees/Default.GetCount(minSalary={minSalary},maxSalary={maxSalary})")]
+        //public int GetCountAttributeRouting([FromODataUri]decimal minSalary, [FromODataUri]decimal maxSalary)
+        //{
+        //    return _employees.Where(e => e.Salary >= minSalary && e.Salary <= maxSalary).Count();
+        //}
+
+        // ~/Employees/Namespace.GetCount(minSalary=60000)
+        // ~/Employees/Namespace.GetCount(minSalary=60000, maxSalary=80000)
+        [HttpGet]
+        public int GetCount(decimal minSalary, decimal maxSalary)
+        {
+            return _employees.Where(e => e.Salary >= minSalary && e.Salary <= maxSalary).Count();
+        }
+
 
         private static void VerifyEmployee(Employee employee)
         {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationEdmModel.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
                 .Returns<int>()
                 .Parameter<string>("Name");
 
+            // Overload with one optional parameter
+            var salaryRangeCount = entityTypeConfigurationOfEmployee.Collection.Function("GetCount")
+                .Returns<int>();
+            salaryRangeCount.Parameter<decimal>("minSalary");
+            salaryRangeCount.Parameter<decimal>("maxSalary").IsOptional = true;
+
             // Function bound to a collection of derived EntityType.
             entityTypeConfigurationOfManager.Collection.Function("GetCount")
                 .Returns<int>();


### PR DESCRIPTION
Here is a start at some optional parameter routing tests.  Didn't get too far, but you're welcome to take these if they'd be useful.

I reverted my local changes that duplicated your changes to EdmModelHelper and ParameterConfiguration.